### PR TITLE
Modifications to NSMenu and NSMenuView to support the global menubar overhaul.

### DIFF
--- a/Source/NSMenu.m
+++ b/Source/NSMenu.m
@@ -476,7 +476,7 @@ static BOOL menuBarVisible = YES;
   if (_menu.horizontal == YES)
     {
       NSRect screenFrame = [[NSScreen mainScreen] frame];
-      origin = NSMakePoint (0, screenFrame.size.height
+      origin = NSMakePoint (32, screenFrame.size.height
                             - [_aWindow frame].size.height);
       origin.y += screenFrame.origin.y;
       [_aWindow setFrameOrigin: origin];
@@ -1592,6 +1592,10 @@ static BOOL menuBarVisible = YES;
                                            + oldWindowFrame.size.height
                                            - newWindowFrame.size.height);
     }
+  if (self._isMain != NO) { 
+  	newWindowFrame.size.width -= 288;
+  }
+
   [_aWindow setFrame: newWindowFrame display: NO];
   
   // Transient

--- a/Source/NSMenuView.m
+++ b/Source/NSMenuView.m
@@ -74,7 +74,8 @@ static NSMapTable *viewInfo = 0;
 
 #define cellRects ((GSIArray)NSMapGet(viewInfo, self))
 
-#define HORIZONTAL_MENU_LEFT_PADDING 8
+#define HORIZONTAL_MENU_RIGHT_PADDING 4
+#define HORIZONTAL_MENU_LEFT_PADDING 4
 
 /*
   NSMenuView contains:
@@ -789,7 +790,7 @@ static float menuBarHeight = 0.0;
         {
           GSCellRect elem;
           NSMenuItemCell *aCell = [self menuItemCellForItemAtIndex: i];
-          float titleWidth = [aCell titleWidth];
+          float titleWidth = [aCell titleWidth] + 4;
 
           if ([aCell imageWidth])
             {


### PR DESCRIPTION
This patch causes the app-specific menubar to be drawn differently:

 - It is reduced in width by (for now) 288 pixels
 - Its X origin is increased by (for now) 32 pixels
 - Menu items have extra padding on the right to balance out that on the left.

This patch is in support of a forthcoming GWorkspace patch which draws an
immovable, always-visible global menubar Z-ordered immediately "below" the
app-specific menubar. This is an approximate implementation of how it works
in Mac OS X.
