### PR TITLE
fixes imyaman/libs-gui-fedora#1

### DIFF
--- a/Source/GSThemeDrawing.m
+++ b/Source/GSThemeDrawing.m
@@ -1347,17 +1347,15 @@
 // the app menu.
 
 	NSString *menuTitle = cell.menuItem.title;
-	NSString *appTitle = [NSBundle.mainBundle.localizedInfoDictionary objectForKey: @"ApplicationName"];
+	NSString *appTitle = [[[NSBundle mainBundle] localizedInfoDictionary] objectForKey: @"ApplicationName"];
 	
   	NSMutableString *mutableAppTitle = [NSMutableString stringWithCapacity: appTitle.length + 5];
 
 	[mutableAppTitle appendString: appTitle];
 	[mutableAppTitle appendString: @"   "];
 
-	NSMutableDictionary *attrs = NSMutableDictionary.dictionary;
-
-	attrs[NSFontAttributeName] = [NSFont boldSystemFontOfSize: 0.0];
-
+        NSMutableDictionary *attrs = [NSMutableDictionary dictionaryWithObject: [NSFont boldSystemFontOfSize: 0.0] forKey: NSFontAttributeName];
+	
 	NSAttributedString *boldTitle = [[NSAttributedString alloc] initWithString: mutableAppTitle
 									attributes: attrs];
 


### PR DESCRIPTION

```
GSThemeDrawing.m: In function ‘-[GSTheme(Drawing) drawTitleForMenuItemCell:withFrame:inView:state:isHorizontal:]’:
GSThemeDrawing.m:1350:39: error: expected ‘:’ before ‘.’ token
 1350 |         NSString *appTitle = [NSBundle.mainBundle.localizedInfoDictionary objectForKey: @"ApplicationName"];
      |                                       ^
      |                                       :
GSThemeDrawing.m:1359:14: error: array subscript is not an integer
 1359 |         attrs[NSFontAttributeName] = [NSFont boldSystemFontOfSize: 0.0];
      |              ^
gmake[4]: *** [/usr/local/share/GNUstep/Makefiles/rules.make:521: obj/libgnustep-gui.obj/GSThemeDrawing.m.o] Error 1
```